### PR TITLE
vswipe: add support for vertical swiping

### DIFF
--- a/plugins/single_plugins/vswipe-processing.hpp
+++ b/plugins/single_plugins/vswipe-processing.hpp
@@ -33,7 +33,7 @@ static inline int vswipe_finish_target(const double accumulated_dx,
         const double move_threshold = 0.35,
         const double fast_threshold = 24)
 {
-    double target_dx = 0;
+    int target_dx = 0;
 
     const bool too_left = vx == 0 && (accumulated_dx > 0.0 || last_deltas > 0.0);
     const bool too_right = vx == vw - 1 && (accumulated_dx < 0.0 || last_deltas < 0.0);


### PR DESCRIPTION
The mechanism for determining whether swiping is horizontal or vertical is simple: we simply wait until a certain threshold is reached in vertical or horizontal direction.


@myfreeweb Might be good to test whether I didn't broke something :)